### PR TITLE
Fix duplicate permissions key in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,15 +2,12 @@ name: Build and Deploy
 
 permissions:
   contents: write
-  
+
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
-
-permissions:
-  contents: write
 
 jobs:
   build:


### PR DESCRIPTION
The top-level permissions block was defined twice, causing GitHub Actions to reject the workflow file as invalid YAML.

https://claude.ai/code/session_01XQQxPwbSmpSw2pemj3Mjy2

## Description

<!-- What did you change? -->

## Type of Change

- [ ] Update existing feature information
- [ ] Add new feature to existing platform
- [ ] Add new platform
- [ ] Fix error/typo
- [ ] Other (describe below)

## Source

<!-- Link to official source verifying this change (required) -->

**Source URL:**

## Checklist

- [ ] I've followed the format in `data/_schema.md`
- [ ] I've updated the `last_verified` date in frontmatter
- [ ] I've included a source link
- [ ] I've run `node scripts/build.js` and verified the output
- [ ] The talking point is presenter-ready (clear, accurate, includes key details)

## Additional Context

<!-- When did this change happen? Any other relevant info? -->
